### PR TITLE
Add simple detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ SBD=../samples/in.sbd && GST_PLUGIN_PATH=. GST_DEBUG=2,sonardetect:6 gst-launch-
 # (tee apparently doesn't go well with filesrc: gst-launch-1.0 filesrc location=../samples/in.sbd ! tee name=t ! queue ! sonarparse ! sonarsink t. ! queue ! nmeaparse ! fakesink)
 ```
 
+Parse sonar and telemetry data from tcp:
+```
+GST_PLUGIN_PATH=. gst-launch-1.0 tcpclientsrc host=192.168.3.58 port=2211 ! sonarparse ! sonarmux name=mux ! sonardetect ! sonarsink tcpclientsrc host=192.168.3.100 port=11000 ! nmeaparse ! mux.
+```
+
 ## Settings on norbit sonar
 
 Connect to control interface:

--- a/src/sonar/nmeaparse.c
+++ b/src/sonar/nmeaparse.c
@@ -1,7 +1,7 @@
 /**
  * SECTION:element-gst_nmeaparse
  *
- * Nmeaparse is a TODO
+ * Nmeaparse parses telemetry data from nmea strings
  *
  *
  * <refsect2>
@@ -241,12 +241,12 @@ gst_nmeaparse_class_init (GstNmeaparseClass * klass)
   gobject_class->set_property = gst_nmeaparse_set_property;
   gobject_class->get_property = gst_nmeaparse_get_property;
 
-  GST_DEBUG_CATEGORY_INIT(nmeaparse_debug, "nmeaparse", 0, "TODO");
+  GST_DEBUG_CATEGORY_INIT(nmeaparse_debug, "nmeaparse", 0, "nmeaparse");
 
 
   gst_element_class_set_static_metadata (gstelement_class, "Nmeaparse",
-      "Transform",
-      "TODO", // TODO
+      "Parse",
+      "Nmeaparse parses telemetry data from nmea strings",
       "Erlend Eriksen <erlend.eriksen@eelume.com>");
 
   gst_element_class_add_static_pad_template (gstelement_class, &gst_nmeaparse_telemetry_src_template);

--- a/src/sonar/norbit_wbms.h
+++ b/src/sonar/norbit_wbms.h
@@ -1,17 +1,13 @@
 #pragma once
 #include <stdint.h>
 
+// adapted from https://github.com/magnuan/wbms_georef/blob/main/src/bathy_packet.h
+
+// TODO: global scope static assert in C
 //#define JOIN(x,y) x ## y
 //#define ECHO(...) __VA_ARGS__
 //#define static_assert(...) void static_assert_helper(const char [__COUNTER__]) {_Static_assert(__VA_ARGS__); }
-#define static_assert(...)
-
-//inline uint64_t nanoseconds() {
-//  struct timespec ts;
-//  clock_gettime(CLOCK_MONOTONIC, &ts);
-//
-//  return (uint64_t)ts.tv_sec * (uint64_t)1e9 + (uint64_t)ts.tv_nsec;
-//}
+//#define static_assert(...)
 
 #pragma pack(4)
 
@@ -25,8 +21,8 @@ typedef struct{
     uint16_t flags;                 /**< Bit0: Mag based detection | Bit1: Phase based detection | Bit2-8: Quality type | Bit9-12: Detection priority */
     uint8_t quality_flags;          /**< Bit0: SNr test pass | Bit1: Colinarity test pass */
     uint8_t quality_val;            /**< Ad-Hoc detection signal quality metric, based on detection strength and variance ovet time and swath */ 
-}detectionpoint_t;
-static_assert(sizeof(detectionpoint_t) == 20);
+}wbms_detectionpoint_t;
+//static_assert(sizeof(wbms_detectionpoint_t) == 20);
 
 typedef enum // : uint32_t
 {
@@ -42,8 +38,8 @@ typedef struct{
     uint32_t version;               /**< WBMS packet version     */
     uint32_t RESERVED;              /**< 4 bytes reserved for furure use */
     uint32_t crc;                   /**< CRC32 of the size-24 bytes following the header  (crc32, zlib-style SEED=0x00000000, POLY=0xEDB88320)*/
-}packet_header_t; //24 Bytes
-static_assert(sizeof(packet_header_t) == 24);
+}wbms_packet_header_t; //24 Bytes
+//static_assert(sizeof(packet_header_t) == 24);
 
 /** BATH_DATA PACKET SUB-HEADER (WBMS Type 1 packet) */
 typedef struct{
@@ -73,21 +69,17 @@ typedef struct{
     float       swath_dir;              /**< Center beam direction in radians */
     float       swath_open;             /**< Swath opening angle, edge to edge of swath in radians.*/
     float       gate_tilt;              /**< Gate tilt, in radians */
-}bath_data_header_t; //88 bytes
-static_assert(sizeof(bath_data_header_t) == 88);
+}wbms_bath_data_header_t; //88 bytes
+//static_assert(sizeof(bath_data_header_t) == 88);
 
 #define BATH_DATA_MAX_DETECTION_POINTS    4096
 
 /** BATHY PACKET, including common header, sub-header and payload */
 typedef struct{
-    packet_header_t         header;                                    //24B
-    bath_data_header_t      sub_header;                                //88B
-    //detectionpoint_t        dp[BATH_DATA_MAX_DETECTION_POINTS];        //20B*4k = 80kB
-    //detectionpoint_t        dp[256];
-    detectionpoint_t        dp[0];
-
-    //int size() const {return sizeof(header) + sizeof(sub_header) + sizeof(detectionpoint_t) * sub_header.N;};
-}bath_data_packet_t;
+    wbms_packet_header_t         header;                                    //24B
+    wbms_bath_data_header_t      sub_header;                                //88B
+    wbms_detectionpoint_t        dp[0];
+}wbms_bath_data_packet_t;
 
 
 typedef struct{
@@ -127,30 +119,13 @@ typedef struct{
     uint16_t    reserved_4;
     float       gate_tilt;              /**< Gate tilt, in radians */
     uint32_t    reserved_5[8];
-}fls_data_header_t;
-static_assert(sizeof(fls_data_header_t) == 168);
+}wbms_fls_data_header_t;
+//static_assert(sizeof(fls_data_header_t) == 168);
 
-#define N_BEAMS 128
 typedef struct{
-    packet_header_t         header;                                    //24B
-    fls_data_header_t       sub_header;                                //168B
+    wbms_packet_header_t         header;                                    //24B
+    wbms_fls_data_header_t       sub_header;                                //168B
     char data[0];
-
-    //uint16_t beam_intensity(int sample_index, int beam_index) const
-    //{
-    //    return reinterpret_cast<const uint16_t*>(data)[sample_index * sub_header.N + beam_index];
-    //}
-
-    //float beam_angle(int beam_index) const
-    //{
-    //    return reinterpret_cast<const float*>(reinterpret_cast<const uint16_t*>(data) + sub_header.M * sub_header.N)[beam_index];
-    //}
-
-    //int size() const
-    //{
-    //    return sizeof(header) + sizeof(sub_header) + sub_header.M * sub_header.N * sizeof(beam_intensity(0,0)) + sub_header.N * sizeof(beam_angle(0));
-    //};
-
-}fls_data_packet_t;
+}wbms_fls_data_packet_t;
 
 #pragma pack()

--- a/src/sonar/openglWp.h
+++ b/src/sonar/openglWp.h
@@ -35,9 +35,6 @@ const GLchar* vertexSource =
 "void main()\n"
 "{\n"
 "    gl_Position = vec4(position, 1.0);\n"
-"    //float tmpscalar = .4-(gl_Position.z)*.5;\n"
-"    //float scalar = clamp(tmpscalar, 0.0, 1.0);\n"
-"    //Color = vec4(scalar*color,1);\n"
 "    Color = vec4(color,1);\n"
 "}\n"
 ;
@@ -114,7 +111,7 @@ int initWp()
     width = 512;
     height = 512;
 
-    window = SDL_CreateWindow("plot", 0, 0,
+    window = SDL_CreateWindow("sonar", 0, 0,
         //SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
         //SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
         //displayMode.w, displayMode.h,

--- a/src/sonar/sonarconvert.c
+++ b/src/sonar/sonarconvert.c
@@ -12,7 +12,7 @@
  */
 
 #include "sonarconvert.h"
-#include "navi.h"
+#include "norbit_wbms.h"
 
 #include <stdio.h>
 
@@ -58,7 +58,7 @@ gst_sonarconvert_transform_ip (GstBaseTransform * basetransform, GstBuffer * buf
 
   GST_DEBUG_OBJECT(sonarconvert, "n_beams: %d, resolution: %d", sonarconvert->n_beams, sonarconvert->resolution);
 
-  const gssize offset = sizeof(packet_header_t) + sizeof(fls_data_header_t);
+  const gssize offset = sizeof(wbms_packet_header_t) + sizeof(wbms_fls_data_header_t);
   const gssize size = sonarconvert->n_beams * sonarconvert->resolution * sizeof(guint16);// + sonarconvert->n_beams * sizeof(float);
   gst_buffer_resize(buf, offset, size);
 

--- a/src/sonar/sonardetect.c
+++ b/src/sonar/sonardetect.c
@@ -77,7 +77,7 @@ gst_sonardetect_transform_ip (GstBaseTransform * basetransform, GstBuffer * buf)
     {
       case WBMS_FLS:
         if (sonardetect->has_telemetry)
-          sonardetect_detect(mapinfo.data, sonardetect->n_beams, sonardetect->resolution, meta_data, tel);
+          sonardetect_detect(buf->pts, mapinfo.data, sonardetect->n_beams, sonardetect->resolution, meta_data, tel);
         break;
       default:
       case WBMS_BATH:

--- a/src/sonar/sonardetect.c
+++ b/src/sonar/sonardetect.c
@@ -1,7 +1,7 @@
 /**
  * SECTION:element-gst_sonardetect
  *
- * Sonardetect is a TODO
+ * Sonardetect detects the first point of contact along each beam and records the index on the first intensity
  *
  *
  * <refsect2>
@@ -30,13 +30,15 @@ GST_STATIC_PAD_TEMPLATE ("src",
         "n_beams = (int) [ 0, MAX ],"
         "resolution = (int) [ 0, MAX ], "
         "framerate = (fraction) [ 0/1, MAX ], "
-        "parsed = (boolean) true ;"
+        "parsed = (boolean) true ,"
+        "detected = (boolean) true ;"
 
         "sonar/bathymetry,"
         "n_beams = (int) [ 0, MAX ],"
         "resolution = (int) 1,"
         "framerate = (fraction) [ 0/1, MAX ], "
-        "parsed = (boolean) true ;"
+        "parsed = (boolean) true ,"
+        "detected = (boolean) true ;"
         )
     );
 
@@ -183,12 +185,12 @@ gst_sonardetect_class_init (GstSonardetectClass * klass)
   gobject_class->set_property = gst_sonardetect_set_property;
   gobject_class->get_property = gst_sonardetect_get_property;
 
-  GST_DEBUG_CATEGORY_INIT(sonardetect_debug, "sonardetect", 0, "TODO");
+  GST_DEBUG_CATEGORY_INIT(sonardetect_debug, "sonardetect", 0, "sonardetect");
 
 
   gst_element_class_set_static_metadata (gstelement_class, "Sonardetect",
       "Transform",
-      "TODO", // TODO
+      "Sonardetect detects the first point of contact along each beam and records the index on the first intensity",
       "Erlend Eriksen <erlend.eriksen@eelume.com>");
 
   gst_element_class_add_static_pad_template (gstelement_class, &gst_sonardetect_sink_template);

--- a/src/sonar/sonardetect.cpp
+++ b/src/sonar/sonardetect.cpp
@@ -1,20 +1,20 @@
 #include "sonardetect.h"
 
-#include "stdio.h"
+#include "stdint.h"
 
-void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, uint32_t n_beams, uint32_t resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel)
+void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, int n_beams, int resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel)
 {
   int16_t* beam_intensities = (int16_t*)(sonar_data + sizeof(packet_header_t) + sizeof(fls_data_header_t));
   float* beam_angles = (float*)(beam_intensities + n_beams * resolution);
 
   for (int beam_index=0; beam_index < n_beams; ++beam_index)
   {
-    int limit = 0;
+    int total_intensity = 0;
 
     for (int range_index=0; range_index < resolution; ++range_index)
     {
       int16_t* beam_intensity = beam_intensities + range_index * n_beams + beam_index;
-      limit += *beam_intensity;
+      total_intensity += *beam_intensity;
 
       // draw cross
       //if ((beam_index == (int)(n_beams / 2))
@@ -23,24 +23,20 @@ void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, uint32_t n_beam
 
       
     }
-    limit /= resolution;
-
-    limit *= 1.7;
+    const float average_intensity = total_intensity / resolution;
+    const float limit = 1.7 * average_intensity;
 
     bool found_largest_intensity = false;
     for (int range_index=1; range_index < resolution; ++range_index)
     {
       int16_t* beam_intensity = beam_intensities + range_index * n_beams + beam_index;
 
-      if ((*beam_intensity > limit) && (beam_intensities[(range_index - 1) * n_beams + beam_index] < limit))
-        found_largest_intensity = true;
-        
-
-      //if (*beam_intensity == largest_signal)
-      //  found_largest_intensity = true;
-
-      if (found_largest_intensity)
-        *beam_intensity *= 3;
+      if ((*beam_intensity > limit) && (beam_intensity[-n_beams] < limit))
+      {
+        // store the index of the first detected point in the first range index for each beam
+        beam_intensities[beam_index] = range_index;
+        break;
+      }
     }
   }
 }

--- a/src/sonar/sonardetect.cpp
+++ b/src/sonar/sonardetect.cpp
@@ -1,0 +1,55 @@
+#include "sonardetect.h"
+
+#include "stdio.h"
+
+void sonardetect_detect(uint8_t* sonar_data, uint32_t n_beams, uint32_t resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel)
+{
+  int16_t* beam_intensities = (int16_t*)(sonar_data + sizeof(packet_header_t) + sizeof(fls_data_header_t));
+  float* beam_angles = (float*)(beam_intensities + n_beams * resolution);
+
+  for (int beam_index=0; beam_index < n_beams; ++beam_index)
+  {
+    int16_t largest_signal = 0;
+
+    int avg = 0;
+
+    for (int range_index=0; range_index < resolution; ++range_index)
+    {
+      int16_t* beam_intensity = beam_intensities + range_index * n_beams + beam_index;
+      avg += *beam_intensity;
+
+
+      //if (*beam_intensity > largest_signal)
+      //  largest_signal = *beam_intensity;
+
+      //float beam_angle = beam_angles[beam_index];
+      //float range = ((meta_data->t0 + range_index) * meta_data->sound_speed) / (2 * meta_data->sample_rate);
+
+      // draw cross
+      //if ((beam_index == (int)(n_beams / 2))
+      //  || range_index == (int)(resolution / 2))
+      //  *beam_intensity = 5000;
+
+      
+    }
+    avg /= resolution;
+
+    avg *= 1.7;
+
+    bool found_largest_intensity = false;
+    for (int range_index=1; range_index < resolution; ++range_index)
+    {
+      int16_t* beam_intensity = beam_intensities + range_index * n_beams + beam_index;
+
+      if ((*beam_intensity > avg) && (beam_intensities[(range_index - 1) * n_beams + beam_index] < avg))
+        found_largest_intensity = true;
+        
+
+      //if (*beam_intensity == largest_signal)
+      //  found_largest_intensity = true;
+
+      if (found_largest_intensity)
+        *beam_intensity *= 3;
+    }
+  }
+}

--- a/src/sonar/sonardetect.cpp
+++ b/src/sonar/sonardetect.cpp
@@ -2,7 +2,7 @@
 
 #include "stdio.h"
 
-void sonardetect_detect(uint8_t* sonar_data, uint32_t n_beams, uint32_t resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel)
+void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, uint32_t n_beams, uint32_t resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel)
 {
   int16_t* beam_intensities = (int16_t*)(sonar_data + sizeof(packet_header_t) + sizeof(fls_data_header_t));
   float* beam_angles = (float*)(beam_intensities + n_beams * resolution);

--- a/src/sonar/sonardetect.cpp
+++ b/src/sonar/sonardetect.cpp
@@ -4,7 +4,7 @@
 
 void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, int n_beams, int resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel)
 {
-  int16_t* beam_intensities = (int16_t*)(sonar_data + sizeof(packet_header_t) + sizeof(fls_data_header_t));
+  int16_t* beam_intensities = (int16_t*)(sonar_data + sizeof(wbms_packet_header_t) + sizeof(wbms_fls_data_header_t));
   float* beam_angles = (float*)(beam_intensities + n_beams * resolution);
 
   for (int beam_index=0; beam_index < n_beams; ++beam_index)

--- a/src/sonar/sonardetect.cpp
+++ b/src/sonar/sonardetect.cpp
@@ -9,21 +9,12 @@ void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, uint32_t n_beam
 
   for (int beam_index=0; beam_index < n_beams; ++beam_index)
   {
-    int16_t largest_signal = 0;
-
-    int avg = 0;
+    int limit = 0;
 
     for (int range_index=0; range_index < resolution; ++range_index)
     {
       int16_t* beam_intensity = beam_intensities + range_index * n_beams + beam_index;
-      avg += *beam_intensity;
-
-
-      //if (*beam_intensity > largest_signal)
-      //  largest_signal = *beam_intensity;
-
-      //float beam_angle = beam_angles[beam_index];
-      //float range = ((meta_data->t0 + range_index) * meta_data->sound_speed) / (2 * meta_data->sample_rate);
+      limit += *beam_intensity;
 
       // draw cross
       //if ((beam_index == (int)(n_beams / 2))
@@ -32,16 +23,16 @@ void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, uint32_t n_beam
 
       
     }
-    avg /= resolution;
+    limit /= resolution;
 
-    avg *= 1.7;
+    limit *= 1.7;
 
     bool found_largest_intensity = false;
     for (int range_index=1; range_index < resolution; ++range_index)
     {
       int16_t* beam_intensity = beam_intensities + range_index * n_beams + beam_index;
 
-      if ((*beam_intensity > avg) && (beam_intensities[(range_index - 1) * n_beams + beam_index] < avg))
+      if ((*beam_intensity > limit) && (beam_intensities[(range_index - 1) * n_beams + beam_index] < limit))
         found_largest_intensity = true;
         
 

--- a/src/sonar/sonardetect.h
+++ b/src/sonar/sonardetect.h
@@ -51,7 +51,7 @@ G_END_DECLS
 
 // sonardetect.cpp functions
 
-void sonardetect_detect(uint8_t* sonar_data, uint32_t n_beams, uint32_t resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel);
+void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, uint32_t n_beams, uint32_t resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/sonar/sonardetect.h
+++ b/src/sonar/sonardetect.h
@@ -6,7 +6,7 @@
 
 #include "sonarparse.h"
 #include "sonarmux.h"
-#include "navi.h"
+#include "norbit_wbms.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sonar/sonardetect.h
+++ b/src/sonar/sonardetect.h
@@ -51,6 +51,7 @@ G_END_DECLS
 
 // sonardetect.cpp functions
 
+// stores the index of the first detected point in the first range index for each beam
 void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, int n_beams, int resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel);
 
 #ifdef __cplusplus

--- a/src/sonar/sonardetect.h
+++ b/src/sonar/sonardetect.h
@@ -51,7 +51,7 @@ G_END_DECLS
 
 // sonardetect.cpp functions
 
-void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, uint32_t n_beams, uint32_t resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel);
+void sonardetect_detect(uint64_t timestamp, uint8_t* sonar_data, int n_beams, int resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/sonar/sonardetect.h
+++ b/src/sonar/sonardetect.h
@@ -4,7 +4,13 @@
 #include <gst/gst.h>
 #include <gst/base/gstbasetransform.h>
 
+#include "sonarparse.h"
+#include "sonarmux.h"
 #include "navi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 G_BEGIN_DECLS
 
@@ -40,5 +46,14 @@ struct _GstSonardetectClass
 GType gst_sonardetect_get_type (void);
 
 G_END_DECLS
+
+
+// sonardetect.cpp functions
+
+void sonardetect_detect(uint8_t* sonar_data, uint32_t n_beams, uint32_t resolution, const GstSonarMetaData *meta_data, const GstSonarTelemetry* tel);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* __GST_SONARDETECT_H__ */

--- a/src/sonar/sonardetect.h
+++ b/src/sonar/sonardetect.h
@@ -36,6 +36,7 @@ struct _GstSonardetect
   wbms_type_t wbms_type;
   guint32 n_beams;
   guint32 resolution;
+  gboolean has_telemetry;
 };
 
 struct _GstSonardetectClass

--- a/src/sonar/sonarmux.c
+++ b/src/sonar/sonarmux.c
@@ -11,7 +11,7 @@
  */
 
 #include "sonarmux.h"
-#include "navi.h"
+#include "norbit_wbms.h"
 #include "nmeaparse.h"
 #include "linalg.h"
 

--- a/src/sonar/sonarmux.c
+++ b/src/sonar/sonarmux.c
@@ -336,7 +336,7 @@ gst_sonarmux_class_init (GstSonarmuxClass * klass)
   aggregator_class->create_new_pad = GST_DEBUG_FUNCPTR (gst_sonarmux_create_new_pad);
   aggregator_class->update_src_caps = GST_DEBUG_FUNCPTR (gst_sonarmux_update_src_caps);
 
-  GST_DEBUG_CATEGORY_INIT(sonarmux_debug, "sonarmux", 0, "TODO");
+  GST_DEBUG_CATEGORY_INIT(sonarmux_debug, "sonarmux", 0, "sonarmux");
 
   gst_element_class_set_static_metadata (gstelement_class, "Sonarmux",
       "Sink",

--- a/src/sonar/sonarparse.c
+++ b/src/sonar/sonarparse.c
@@ -93,12 +93,12 @@ gst_sonarparse_handle_frame (GstBaseParse * baseparse, GstBaseParseFrame * frame
   gst_byte_reader_skip (&reader, *skipsize);
 
   const guint8 *header_data = NULL;
-  const packet_header_t* header = NULL;
+  const wbms_packet_header_t* header = NULL;
   if (!gst_byte_reader_get_data (&reader, sizeof(*header), &header_data))
     exit;
-  header = (const packet_header_t*)header_data;
+  header = (const wbms_packet_header_t*)header_data;
 
-  if (header->size < sizeof(packet_header_t))
+  if (header->size < sizeof(wbms_packet_header_t))
   {
     GST_ERROR_OBJECT(sonarparse, "size specified in header is too small: %d", header->size);
     gst_buffer_unmap (frame->buffer, &mapinfo);
@@ -122,10 +122,10 @@ gst_sonarparse_handle_frame (GstBaseParse * baseparse, GstBaseParseFrame * frame
     case WBMS_BATH:
     {
       GST_DEBUG_OBJECT(sonarparse, "sonar type is bathymetry");
-      const bath_data_header_t* sub_header;
+      const wbms_bath_data_header_t* sub_header;
       if (!gst_byte_reader_get_data (&reader, sizeof(*sub_header), &sub_header_data))
         exit;
-      sub_header = (bath_data_header_t*)sub_header_data;
+      sub_header = (wbms_bath_data_header_t*)sub_header_data;
 
       sub_header_time = sub_header->time;
       sonarparse->caps_name = "sonar/bathymetry";
@@ -145,10 +145,10 @@ gst_sonarparse_handle_frame (GstBaseParse * baseparse, GstBaseParseFrame * frame
     case WBMS_FLS: // fls
     {
       GST_DEBUG_OBJECT(sonarparse, "sonar type is fls");
-      const fls_data_header_t* sub_header;
+      const wbms_fls_data_header_t* sub_header;
       if (!gst_byte_reader_get_data (&reader, sizeof(*sub_header), &sub_header_data))
         exit;
-      sub_header = (fls_data_header_t*)sub_header_data;
+      sub_header = (wbms_fls_data_header_t*)sub_header_data;
 
       g_assert(sub_header->dtype == 3); // int16
       sub_header_time = sub_header->time;
@@ -256,7 +256,7 @@ gst_sonarparse_start (GstBaseParse * baseparse)
 
   GST_DEBUG_OBJECT (sonarparse, "start");
 
-  gst_base_parse_set_min_frame_size (baseparse, sizeof(packet_header_t));
+  gst_base_parse_set_min_frame_size (baseparse, sizeof(wbms_packet_header_t));
 
   return TRUE;
 }

--- a/src/sonar/sonarparse.c
+++ b/src/sonar/sonarparse.c
@@ -1,7 +1,7 @@
 /**
  * SECTION:element-gst_sonarparse
  *
- * Sonarparse is a TODO
+ * Sonarparse parses Norbit WBMS sonar data
  *
  *
  * <refsect2>
@@ -313,12 +313,12 @@ gst_sonarparse_class_init (GstSonarparseClass * klass)
   gobject_class->set_property = gst_sonarparse_set_property;
   gobject_class->get_property = gst_sonarparse_get_property;
 
-  GST_DEBUG_CATEGORY_INIT(sonarparse_debug, "sonarparse", 0, "TODO");
+  GST_DEBUG_CATEGORY_INIT(sonarparse_debug, "sonarparse", 0, "sonarparse");
 
 
   gst_element_class_set_static_metadata (gstelement_class, "Sonarparse",
-      "Transform",
-      "TODO", // TODO
+      "Parse",
+      "Sonarparse parses Norbit WBMS sonar data",
       "Erlend Eriksen <erlend.eriksen@eelume.com>");
 
   gst_element_class_add_static_pad_template (gstelement_class, &gst_sonarparse_sink_template);

--- a/src/sonar/sonarparse.c
+++ b/src/sonar/sonarparse.c
@@ -37,16 +37,14 @@ GST_STATIC_PAD_TEMPLATE ("src",
         "n_beams = (int) [ 0, MAX ],"
         "resolution = (int) [ 0, MAX ], "
         "framerate = (fraction) [ 0/1, MAX ], "
-        "parsed = (boolean) true ,"
-        "has_telemetry = (boolean) false ;"
+        "parsed = (boolean) true ;"
 
         "sonar/bathymetry, "
         //"format = (string) { norbit }, "
         "n_beams = (int) [ 0, MAX ],"
         "resolution = (int) 1, "
         "framerate = (fraction) [ 0/1, MAX ], "
-        "parsed = (boolean) true ,"
-        "has_telemetry = (boolean) false ;"
+        "parsed = (boolean) true ;"
         )
     );
 
@@ -184,7 +182,6 @@ gst_sonarparse_handle_frame (GstBaseParse * baseparse, GstBaseParseFrame * frame
       , "resolution", G_TYPE_INT, sonarparse->resolution
       , "framerate", GST_TYPE_FRACTION, sonarparse->framerate, 1
       , "parsed", G_TYPE_BOOLEAN, TRUE
-      , "has_telemetry", G_TYPE_BOOLEAN, FALSE
       , NULL);
 
     GST_DEBUG_OBJECT (sonarparse, "setting downstream caps on %s:%s to %" GST_PTR_FORMAT,

--- a/src/sonar/sonarparse.h
+++ b/src/sonar/sonarparse.h
@@ -5,7 +5,7 @@
 #include <gst/gst.h>
 #include <gst/base/gstbaseparse.h>
 
-#include "navi.h"
+#include "norbit_wbms.h"
 
 G_BEGIN_DECLS
 

--- a/src/sonar/sonarsink.c
+++ b/src/sonar/sonarsink.c
@@ -64,7 +64,7 @@ gst_sonarsink_render (GstBaseSink * basesink, GstBuffer * buf)
   {
     case WBMS_FLS:
     {
-      const int16_t* beam_intensities = (const int16_t*)(mapinfo.data + sizeof(packet_header_t) + sizeof(fls_data_header_t));
+      const int16_t* beam_intensities = (const int16_t*)(mapinfo.data + sizeof(wbms_packet_header_t) + sizeof(wbms_fls_data_header_t));
       const float* beam_angles = (const float*)(beam_intensities + sonarsink->n_beams * sonarsink->resolution);
 
       const float max_range = ((meta_data->t0 + sonarsink->resolution) * meta_data->sound_speed) / (2 * meta_data->sample_rate);
@@ -140,11 +140,11 @@ gst_sonarsink_render (GstBaseSink * basesink, GstBuffer * buf)
     {
       g_assert(sonarsink->resolution == 1);
 
-      const detectionpoint_t* detection_points = (const detectionpoint_t*)(mapinfo.data + sizeof(packet_header_t) + sizeof(bath_data_header_t));
+      const wbms_detectionpoint_t* detection_points = (const wbms_detectionpoint_t*)(mapinfo.data + sizeof(wbms_packet_header_t) + sizeof(wbms_bath_data_header_t));
 
       for (int beam_index=0; beam_index < sonarsink->n_beams; ++beam_index)
       {
-        const detectionpoint_t* dp = detection_points + beam_index;
+        const wbms_detectionpoint_t* dp = detection_points + beam_index;
 
         float range = (dp->sample_number * meta_data->sound_speed) / (2 * meta_data->sample_rate);
 

--- a/src/sonar/sonarsink.c
+++ b/src/sonar/sonarsink.c
@@ -67,6 +67,8 @@ gst_sonarsink_render (GstBaseSink * basesink, GstBuffer * buf)
       const int16_t* beam_intensities = (const int16_t*)(mapinfo.data + sizeof(packet_header_t) + sizeof(fls_data_header_t));
       const float* beam_angles = (const float*)(beam_intensities + sonarsink->n_beams * sonarsink->resolution);
 
+      const float max_range = ((meta_data->t0 + sonarsink->resolution) * meta_data->sound_speed) / (2 * meta_data->sample_rate);
+
       const float total_gain = sonarsink->gain / meta_data->gain;
 
       for (int range_index=0; range_index < sonarsink->resolution; ++range_index)
@@ -75,12 +77,12 @@ gst_sonarsink_render (GstBaseSink * basesink, GstBuffer * buf)
         {
           int16_t beam_intensity = beam_intensities[range_index * sonarsink->n_beams + beam_index];
           float beam_angle = beam_angles[beam_index];
-          //float range = ((meta_data->t0 + range_index) * meta_data->sound_speed) / (2 * meta_data->sample_rate);
+          float range = ((meta_data->t0 + range_index) * meta_data->sound_speed) / (2 * meta_data->sample_rate);
 
           int vertex_index = 3 * (beam_index * sonarsink->resolution + range_index);
           float* vertex = sonarsink->vertices + vertex_index;
 
-          float range_norm = (float)range_index / (float)sonarsink->resolution;
+          float range_norm = range / max_range;
 
           vertex[0] = -sin(beam_angle) * range_norm * sonarsink->zoom;
           vertex[1] = -1 + cos(beam_angle) * range_norm * sonarsink->zoom;

--- a/src/sonar/sonarsink.c
+++ b/src/sonar/sonarsink.c
@@ -37,7 +37,7 @@ static GstStaticPadTemplate gst_sonarsink_sink_template =
 GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("sonar/multibeam, detected=(boolean){false,true}; sonar/bathymetry, detected=(boolean){false,true}")
+    GST_STATIC_CAPS ("sonar/multibeam ; sonar/bathymetry")
     );
 
 static GstFlowReturn

--- a/src/sonar/sonarsink.c
+++ b/src/sonar/sonarsink.c
@@ -1,7 +1,7 @@
 /**
  * SECTION:element-gst_sonarsink
  *
- * Sonarsink is a TODO
+ * Sonarsink visualizes sonar data
  *
  *
  * <refsect2>
@@ -306,7 +306,7 @@ gst_sonarsink_class_init (GstSonarsinkClass * klass)
   basesink_class->render = GST_DEBUG_FUNCPTR (gst_sonarsink_render);
   basesink_class->set_caps = GST_DEBUG_FUNCPTR (gst_sonarsink_set_caps);
 
-  GST_DEBUG_CATEGORY_INIT(sonarsink_debug, "sonarsink", 0, "TODO");
+  GST_DEBUG_CATEGORY_INIT(sonarsink_debug, "sonarsink", 0, "sonarsink");
 
   g_object_class_install_property (G_OBJECT_CLASS (klass), PROP_ZOOM,
       g_param_spec_double ("zoom", "zoom",
@@ -320,7 +320,7 @@ gst_sonarsink_class_init (GstSonarsinkClass * klass)
 
   gst_element_class_set_static_metadata (gstelement_class, "Sonarsink",
       "Sink",
-      "TODO", // TODO
+      "visualizes sonar data",
       "Erlend Eriksen <erlend.eriksen@eelume.com>");
 
   gst_element_class_add_static_pad_template (gstelement_class, &gst_sonarsink_sink_template);

--- a/src/sonar/sonarsink.c
+++ b/src/sonar/sonarsink.c
@@ -97,9 +97,18 @@ gst_sonarsink_render (GstBaseSink * basesink, GstBuffer * buf)
           }
 
           float* color = sonarsink->colors + vertex_index;
-          color[0] = I;
-          color[1] = I;
-          color[2] = I;
+          if (beam_intensity % 3 == 0)
+          {
+            color[0] = I;
+            color[1] = 0;
+            color[2] = 0;
+          }
+          else
+          {
+            color[0] = I;
+            color[1] = I;
+            color[2] = I;
+          }
         }
       }
       break;

--- a/src/sonar/sonarsink.h
+++ b/src/sonar/sonarsink.h
@@ -30,6 +30,7 @@ struct _GstSonarsink
   wbms_type_t wbms_type;
   guint32 n_beams;
   guint32 resolution;
+  gboolean detected; // if detection was run on the data
 
   float* vertices;
   float* colors;

--- a/src/sonar/sonarsink.h
+++ b/src/sonar/sonarsink.h
@@ -4,7 +4,7 @@
 #include <gst/gst.h>
 #include <gst/base/gstbasesink.h>
 
-#include "navi.h"
+#include "norbit_wbms.h"
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
Adds a sonardetect element with  basic detection of first point of contact along each beam. It saves the index of the contact point over the intensity on the first range index for each beam, which is a bit ugly. It's visualized in sonarsink.